### PR TITLE
Fix some type instabilities 

### DIFF
--- a/docs/src/kerneldowndater.md
+++ b/docs/src/kerneldowndater.md
@@ -13,12 +13,12 @@ where ``\alpha`` is a constant chosen to zero out one of the weights while keepi
 However, in Carathéodory pruning, at each step, ``S`` is typically only changed by removing (or sometimes adding) a few elements at a time.
 Thus, it can be wasteful to fully recompute the QR decomposition at each step. 
 
-`CaratheodoryPruning.jl` comes with several built-in Downdater options. They can be easily used by calling `caratheodory_pruning(V, w_in, kernel=:KERNEL)`, replacing `:KERNEL` with the appropriate symbol. 
+`CaratheodoryPruning.jl` comes with several built-in Downdater options. They can be easily used by calling `caratheodory_pruning(V, w_in, kernel=KERNEL)`, replacing `KERNEL` with the appropriate method. 
 
 To implement your own `KernelDowndater` type, create a struct that inherits from KernelDowndater, and implement the necessary methods.
 ```julia
-struct MyKernelDowndater <: KernelDowndater
-    V::AbstractMatrix
+struct MyKernelDowndater{TV <: AbstractMatrix} <: KernelDowndater
+    V::TV
     # Other necessary components
 end
 
@@ -39,11 +39,9 @@ kd = MyKernelDowndater(V, additional_args)
 caratheodory_pruning(V, w_in, kd, prune_weights_first!)
 ```
 
-Below are the available `KernelDowndater` options implemented in `CaratheodoryPruning.jl`.
+Below are the available `KernelDowndater` options implemented in `CaratheodoryPruning.jl`. Note that the default `KernelDowndater` is the `GivensUpDowndater`
 
 ### FullQRDowndater
-
-Access with the kernel symbols `:FullQRDowndater` or `:FullQR`.
 
 ```@docs
 FullQRDowndater
@@ -51,15 +49,11 @@ FullQRDowndater
 
 ### GivensDowndater
 
-Access with the kernel symbols `:GivensDowndater` or `:Givens`.
-
 ```@docs
 GivensDowndater
 ```
 
 ### CholeskyDowndater
-
-Access with the kernel symbols `:CholeskyDowndater` or `:Cholesky`.
 
 ```@docs
 CholeskyDowndater
@@ -67,15 +61,11 @@ CholeskyDowndater
 
 ### FullQRUpDowndater
 
-Access with the kernel symbols `:FullQRUpDowndater` or `:FullQRUpDown`.
-
 ```@docs
 FullQRUpDowndater
 ```
 
 ### GivensUpDowndater
-
-Access with the kernel symbols `:GivensUpDowndater` or `:GivensUpDown`.
 
 ```@docs
 GivensUpDowndater

--- a/docs/src/pruning.md
+++ b/docs/src/pruning.md
@@ -10,12 +10,11 @@ These can be computed by the `get_alpha_k0s` method.
 CaratheodoryPruning.get_alpha_k0s
 ```
 
-`CaratheodoryPruning.jl` comes with several built-in pruning options. They can be easily used by calling `caratheodory_pruning(V, w_in, pruning=:PRUNING)`, replacing `:PRUNING` with the appropriate symbol. 
+`CaratheodoryPruning.jl` comes with several built-in pruning options. They can be easily used by calling `caratheodory_pruning(V, w_in, pruning=PRUNING)`, replacing `PRUNING` with the appropriate method. 
 
 ### Prune first
 
 Prunes using the first kernel vector in `kvecs`.
-Access with the pruning symbol `:first`.
 
 ```@docs
 prune_weights_first!
@@ -23,7 +22,6 @@ prune_weights_first!
 ### Prune Minimum Absolute Value
 
 Prunes according to the kernel vector in `kvecs` which results in the minimum absolute value multiple added.
-Access with the pruning symbol `:minabs`.
 
 ```@docs
 prune_weights_minabs!

--- a/examples/benchmark.jl
+++ b/examples/benchmark.jl
@@ -4,11 +4,11 @@ using ProgressBars
 using Random: seed!
 
 
-opts = (FullQR = Dict(:kernel => :FullQR),
-        GivensQR = Dict(:kernel => :Givens),
-        Cholesky = Dict(:kernel => :Cholesky),
-        FullQRUpDown = Dict(:kernel => :FullQRUpDown),
-        GivensUpDown = Dict(:kernel => :GivensUpDown)
+opts = (FullQR = Dict(:kernel => FullQRDowndater),
+        GivensQR = Dict(:kernel => GivensDowndater),
+        Cholesky = Dict(:kernel => CholeskyDowndater),
+        FullQRUpDown = Dict(:kernel => FullQRUpDowndater),
+        GivensUpDown = Dict(:kernel => GivensUpDowndater)
 )
 
 N = 2 ^ 3

--- a/examples/simple_ex.jl
+++ b/examples/simple_ex.jl
@@ -11,10 +11,10 @@ w = rand(M)
 
 w_pruned, inds = caratheodory_pruning(V, w) # GivensUpDown Method
 # w_pruned, inds = caratheodory_pruning(V, w, kernel=FullQRDowndater)
-# w_pruned, inds = caratheodory_pruning(V, w, kernel=:GivensDowndater)
-# w_pruned, inds = caratheodory_pruning(V, w, kernel=:CholeskyDowndater)
-# w_pruned, inds = caratheodory_pruning(V, w, kernel=:FullQRUpDowndater)
-# w_pruned, inds = caratheodory_pruning(V, w, kernel=:GivensUpDowndater)
+# w_pruned, inds = caratheodory_pruning(V, w, kernel=GivensDowndater)
+# w_pruned, inds = caratheodory_pruning(V, w, kernel=CholeskyDowndater)
+# w_pruned, inds = caratheodory_pruning(V, w, kernel=FullQRUpDowndater)
+# w_pruned, inds = caratheodory_pruning(V, w, kernel=GivensUpDowndater)
 
 η_comp = V[inds,:]' * w_pruned[inds]
 

--- a/examples/simple_ex.jl
+++ b/examples/simple_ex.jl
@@ -10,11 +10,11 @@ w = rand(M)
 η = V'w
 
 w_pruned, inds = caratheodory_pruning(V, w) # GivensUpDown Method
-# w_pruned, inds = caratheodory_pruning(V, w, kernel=:FullQR)
-# w_pruned, inds = caratheodory_pruning(V, w, kernel=:Givens)
-# w_pruned, inds = caratheodory_pruning(V, w, kernel=:Cholesky)
-# w_pruned, inds = caratheodory_pruning(V, w, kernel=:FullQRUpDown)
-# w_pruned, inds = caratheodory_pruning(V, w, kernel=:GivensUpDown)
+# w_pruned, inds = caratheodory_pruning(V, w, kernel=FullQRDowndater)
+# w_pruned, inds = caratheodory_pruning(V, w, kernel=:GivensDowndater)
+# w_pruned, inds = caratheodory_pruning(V, w, kernel=:CholeskyDowndater)
+# w_pruned, inds = caratheodory_pruning(V, w, kernel=:FullQRUpDowndater)
+# w_pruned, inds = caratheodory_pruning(V, w, kernel=:GivensUpDowndater)
 
 η_comp = V[inds,:]' * w_pruned[inds]
 

--- a/src/caratheodory.jl
+++ b/src/caratheodory.jl
@@ -46,8 +46,7 @@ function caratheodory_pruning(V, w_in, kernel_downdater::KernelDowndater,
     if isa(V, OnDemandMatrix) && V.cols
         @warn "Performance will be slow with current OnDemandMatrix implementation \n         For better performance, transpose OnDemandMatrix storage"
     end
-    T = promote_type(Float64, eltype(w_in), eltype(V))
-    w = T.(w_in)
+    w = copy(w_in)
     m = M-N
     ct = 1
     err = 0.0

--- a/src/caratheodory.jl
+++ b/src/caratheodory.jl
@@ -28,11 +28,10 @@ corresponding errors in moments, `err`. If both `return_error` and
 to evaluate final error, only used if `caratheodory_correction=true` 
 or `return_error=true`. Defaults to LinearAlgebra.jl's norm method.
 """
-function caratheodory_pruning(V::MType, w_in::VType, kernel_downdater::KernelDowndater, 
-                              prune_weights!::Function; caratheodory_correction::Bool=true, 
-                              progress::Bool=false, zero_tol::Real=1e-16, return_error::Bool=false, 
-                              errnorm::Function=norm
-    ) where MType<:AbstractMatrix{T} where VType<:AbstractVector{T} where T
+function caratheodory_pruning(V, w_in, kernel_downdater::KernelDowndater, 
+                              prune_weights!::Function; caratheodory_correction=true, 
+                              progress::Bool=false, zero_tol=1e-16, return_error=false, 
+                              errnorm::Function=norm) 
     
     M, N = size(V)
     if M < N
@@ -127,11 +126,11 @@ function caratheodory_pruning(V::MType, w_in::VType, kernel_downdater::KernelDow
             end
         end
     end
-    return (w::VType, inds::Vector{Int}, err::Float64)
+    return w, inds, err
 end
 
 """
-`caratheodory_pruning(V, w_in[; kernel=:GivensUpDown, pruning=:first, caratheodory_correction=true, return_error=false, errnorm=norm, zero_tol=1e-16, progress=false, kernel_kwargs...])`
+`caratheodory_pruning(V, w_in[; kernel=GivensUpDownDater, pruning=:first, caratheodory_correction=true, return_error=false, errnorm=norm, zero_tol=1e-16, progress=false, kernel_kwargs...])`
 
 Helper method for calling the base `caratheodory_pruning` method.
 
@@ -147,11 +146,10 @@ on what is passed in. Options are `:first` or `:minabs`.
 
 See the other `caratheodory_pruning` docstring for info on other arguments.
 """
-function caratheodory_pruning(V::MType, w_in::VType; kernel::Symbol=:GivensUpDown, 
-                              pruning::Symbol=:first, caratheodory_correction::Bool=true, 
-                              return_error::Bool=false, errnorm::Function=norm, zero_tol::Real=1e-16, 
-                              progress::Bool=false, kernel_kwargs...
-    ) where MType<:AbstractMatrix{T} where VType<:AbstractVector{T} where T
+function caratheodory_pruning(V, w_in; kernel=GivensUpDowndater, 
+                              pruning=:first, caratheodory_correction=true, 
+                              return_error=false, errnorm=norm, zero_tol=1e-16, 
+                              progress=false, kernel_kwargs...) 
 
     M, N = size(V)
     if M < N

--- a/src/caratheodory.jl
+++ b/src/caratheodory.jl
@@ -137,9 +137,8 @@ Helper method for calling the base `caratheodory_pruning` method.
 Takes in a symbol for `kernel`, and forms a `KernelDowndater` object depending
 on what is passed in. Also passes additional kwargs into the `KernelDowndater`:
 
-Options include `:FullQRDowndater` or `:FullQR`, `:GivensDowndater` or `:Givens`,
-`:CholeskyDowndater` or `:Cholesky`, `:FullQRUpDowndater` or `:FullQRUpDown`,
-and `:GivensUpDownDater` or `:GivensUpDown`.
+Options include `FullQRDowndater`, `GivensDowndater`, `CholeskyDowndater`, 
+`FullQRUpDowndater`, and `GivensUpDownDater`.
 
 Takes in a symbol for `pruning`, and chooses a pruning method depending
 on what is passed in. Options are `:first` or `:minabs`.
@@ -155,21 +154,7 @@ function caratheodory_pruning(V, w_in; kernel=GivensUpDowndater,
     if M < N
         V = transpose(V)
     end
-    kernel_downdater = begin
-        if kernel in (:FullQRDowndater, :FullQR)
-            FullQRDowndater(V; kernel_kwargs...)
-        elseif kernel in (:GivensDowndater, :Givens)
-            GivensDowndater(V; kernel_kwargs...)
-        elseif kernel in (:CholeskyDowndater, :Cholesky)
-            CholeskyDowndater(V; kernel_kwargs...)
-        elseif kernel in (:FullQRUpDowndater, :FullQRUpDown)
-            FullQRUpDowndater(V; kernel_kwargs...)
-        elseif kernel in (:GivensUpDowndater, :GivensUpDown)
-            GivensUpDowndater(V; kernel_kwargs...)
-        else
-            error("Unrecognized kernel choice: $(kernel)")
-        end
-    end
+    kernel_downdater = kernel(V; kernel_kwargs...)
     prune_weights! = begin
         if pruning == :first
             prune_weights_first!

--- a/src/ondemand_vector.jl
+++ b/src/ondemand_vector.jl
@@ -52,7 +52,7 @@ function Base.show(io::Core.IO, M::OnDemandVector{T}) where T
 end
 
 function Base.copy(M::OnDemandVector{T}) where T
-    return OnDemandVector(M.n, copy(M.elems), M.elemfun)
+    return OnDemandVector{T}(M.n, copy(M.elems), M.elemfun)
 end
 
 function Base.getindex(M::OnDemandVector, idx::Vararg{Int,1})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ using LinearAlgebra: norm
     @inferred caratheodory_pruning(V, w)
     Vtw = V'w
     tol = 1e-12
-    @testset "Kernel choice $kernel" for kernel in (:FullQR, :Givens, :Cholesky, :FullQRUpDown, :GivensUpDown)
+    @testset "Kernel choice $kernel" for kernel in (FullQRDowndater, GivensDowndater, CholeskyDowndater, FullQRUpDowndater, GivensUpDowndater)
         for pruning in (:first, :minabs)
             for caratheodory_correction in (true,false)
                 for k in (1,5)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ using LinearAlgebra: norm
     Vtw = V'w
     tol = 1e-12
     @testset "Kernel choice $kernel" for kernel in (FullQRDowndater, GivensDowndater, CholeskyDowndater, FullQRUpDowndater, GivensUpDowndater)
-        for pruning in (:first, :minabs)
+        for pruning in (prune_weights_first!, prune_weights_minabs!)
             for caratheodory_correction in (true,false)
                 for k in (1,5)
                     neww, inds = caratheodory_pruning(V, w, kernel=kernel, pruning=pruning, 


### PR DESCRIPTION
@fbelik this PR is mostly me experimenting with the code internals to avoid things that can lead to type instabilities. 
 
I'm not sure how much of this is worth incorporating. The main changes are using type parameters in the structs instead of abstract types, which I think is a generally good practice (I'm surprised there weren't additional type instabilities before). 

The other changes are less important, and can be scrapped: 
* removing some unnecessary type annotations (Julia usually suggests minimal type annotations unless necessary for dispatch/specialization)
* removing the symbol branching when choosing the kernel downdater. This is a pretty major API change, and the type instability it avoided is just the `w::Vector{Int}` case, which throws an error anyways, so I'm not sure it's worth incorporating.
