### PR TITLE
Vandermonde Vectors

### DIFF
--- a/src/CaratheodoryPruning.jl
+++ b/src/CaratheodoryPruning.jl
@@ -8,6 +8,7 @@ using ProgressBars: ProgressBar, update
 include("utils.jl")
 include("ondemand_matrix.jl")
 include("ondemand_vector.jl")
+include("vandermonde_vec.jl")
 include("kernel.jl")
 include("pruning_weights.jl")
 include("caratheodory.jl")
@@ -15,6 +16,8 @@ include("caratheodory.jl")
 export OnDemandMatrix
 export OnDemandVector
 export forget!
+export VandermondeVector
+export getpt
 export CholeskyDowndater
 export FullQRDowndater
 export GivensDowndater

--- a/src/ondemand_matrix.jl
+++ b/src/ondemand_matrix.jl
@@ -33,15 +33,26 @@ struct OnDemandMatrix{T,TV<:AbstractVector{T}} <: AbstractMatrix{T}
 end
 
 """
-`OnDemandMatrix(n::Int, m::Int, vecfun::Function; by=:cols, T=Float64, TV=Vector{T})`
+`OnDemandMatrix(n::Int, m::Int, vecfun::Function; by=:cols, T=nothing, TV=nothing)`
 
 Forms an `n×m` `OnDemandMatrix` whose columns (or rows if `by==:rows`) are
-formed when needed by `vecfun(i::Int)`. Default eltype is `T=Float64` and
-default vector type is `TV=Vector{Float64}`.
+formed when needed by `vecfun(i::Int)`. If `T` and `TV` are not passed in,
+then `vecfun(1)` is called to determine the types. If one of the two is provided,
+the other is inferred.
 """
-function OnDemandMatrix(n::Int, m::Int, vecfun::Function; by=:cols, T=Float64, TV=Vector{T})
+function OnDemandMatrix(n::Int, m::Int, vecfun::Function; by=:cols, T=nothing, TV=nothing)
     @assert (by in (:rows, :cols)) "by argument must be either :cols or :rows"
-    vecs = Dict{Int,AbstractVector{T}}()
+    if isnothing(T) && isnothing(TV)
+        ex = vecfun(1)
+        T = eltype(ex)
+        TV = typeof(ex)
+    elseif isnothing(T)
+        T = eltype(TV)
+    elseif isnothing(TV)
+        ex = vecfun(1)
+        TV = typeof(ex)
+    end
+    vecs = Dict{Int,TV}()
     return OnDemandMatrix{T,TV}(n, m, vecs, vecfun, by==:cols)
 end
 

--- a/src/vandermonde_vec.jl
+++ b/src/vandermonde_vec.jl
@@ -1,0 +1,71 @@
+"""
+`VandermondeVector{T,TV<:AbstractVector{T},TP} <: AbstractVector{T}`
+
+Vector subtype useful for storing a slice (row or column) of a Vandermonde 
+matrix along with the point used to form the slice. The slice is stored in 
+`vec` and the point is stored in `pt`. Behaves like a normal vector with 
+contents `vec`.
+
+Given `v = VandermondeVector(vec, pt)`, the point can be accessed with 
+`getpt(v)` or `v.pt`.
+"""
+struct VandermondeVector{T,TV<:AbstractVector{T},TP} <: AbstractVector{T}
+    vec::TV
+    pt::TP
+end
+
+"""
+`VandermondeVector(vec::TV, addl::TP) where TV<:AbstractVector{T} where T where TP`
+
+Forms a `VandermondeVector` with contents `vec` and corresponding point
+`pt`.
+"""
+function VandermondeVector(vec::TV, pt::TP=nothing) where TV<:AbstractVector{T} where T where TP
+    return VandermondeVector{T,TV,TP}(vec,pt)
+end
+
+function Base.size(v::VandermondeVector)
+    return size(v.vec)
+end
+
+function Base.getindex(v::VandermondeVector, idx::Vararg{Int,1})
+    return getindex(v.vec, idx[1])
+end
+
+function Base.setindex!(v::VandermondeVector, val, idx::Vararg{Int,1})
+    setindex!(v.vec, val, idx[1])
+end
+
+"""
+`getpt(v::VandermondeVector)`
+
+Returns the stored point, `v.pt`.
+"""
+function getpt(v::VandermondeVector)
+    return v.pt
+end
+
+function Base.similar(v::VandermondeVector{T,TV,TP}) where T where TV where TP
+    return VandermondeVector{T,TV,TP}(similar(v.vec), v.pt)
+end
+
+function Base.similar(v::VandermondeVector{T,TV,TP}, S::Type) where T where TV where TP
+    vec = similar(v.vec, S)
+    TVnew = typeof(vec)
+    return VandermondeVector{S,TVnew,TP}(vec, v.pt)
+end
+
+Base.Broadcast.BroadcastStyle(::Type{<:VandermondeVector}) = Base.Broadcast.ArrayStyle{VandermondeVector}()
+
+function Base.similar(bc::Base.Broadcast.Broadcasted{Base.Broadcast.ArrayStyle{VandermondeVector}}, S::Type)
+    v = find_vv(bc)
+    VandermondeVector(similar(v.vec, S), v.pt)
+end
+
+# For broadcasting purposes: https://docs.julialang.org/en/v1/manual/interfaces/#writing-binary-broadcasting-rules
+find_vv(bc::Base.Broadcast.Broadcasted) = find_vv(bc.args)
+find_vv(args::Tuple) = find_vv(find_vv(args[1]), Base.tail(args))
+find_vv(x) = x
+find_vv(::Tuple{}) = nothing
+find_vv(v::VandermondeVector, rest) = v
+find_vv(::Any, rest) = find_vv(rest)

--- a/src/vandermonde_vec.jl
+++ b/src/vandermonde_vec.jl
@@ -1,6 +1,8 @@
 """
 `VandermondeVector{T,TV<:AbstractVector{T},TP} <: AbstractVector{T}`
 
+`v = VandermondeVector(vec, [pt=nothing])`
+
 Vector subtype useful for storing a slice (row or column) of a Vandermonde 
 matrix along with the point used to form the slice. The slice is stored in 
 `vec` and the point is stored in `pt`. Behaves like a normal vector with 
@@ -12,16 +14,9 @@ Given `v = VandermondeVector(vec, pt)`, the point can be accessed with
 struct VandermondeVector{T,TV<:AbstractVector{T},TP} <: AbstractVector{T}
     vec::TV
     pt::TP
-end
-
-"""
-`VandermondeVector(vec::TV, addl::TP) where TV<:AbstractVector{T} where T where TP`
-
-Forms a `VandermondeVector` with contents `vec` and corresponding point
-`pt`.
-"""
-function VandermondeVector(vec::TV, pt::TP=nothing) where TV<:AbstractVector{T} where T where TP
-    return VandermondeVector{T,TV,TP}(vec,pt)
+    function VandermondeVector(vec::TV, pt::TP=nothing) where TV<:AbstractVector{T} where T where TP
+        return new{T,TV,TP}(vec,pt)
+    end
 end
 
 function Base.size(v::VandermondeVector)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,15 @@ using LinearAlgebra: norm
             end
         end
     end
+    @testset "VandermondeVector" begin
+        vect = collect(1.0:1:5)
+        pt = collect(1.0:1:1)
+        v = VandermondeVector(vect, pt)
+        @test v == vect
+        @test v ./ v == ones(5)
+        @test v.pt == pt
+        @test getpt(v) == pt
+    end
     @testset "OnDemandMatrix $selection-wise" for selection in (:cols,:rows)
         M = OnDemandMatrix(5, 5, i -> [1.0*(i==j) for j in 1:5], by=selection, T=Float64)
         M[2,2]


### PR DESCRIPTION
The columns, or rows, of the Vandermonde matrix correspond to evaluations of all of the basis functions over a given point. In the regime where the Vandermonde matrix is larger than one would want to store in memory, one could use `OnDemandMatrices` to store the columns of the Vandermonde matrix. However, then it is also necessary to store the corresponding `d`-dimensional points. If we would like to efficiently store these points on-demand as well, they should be stored within the columns, or rows, of the Vandermonde matrix which are stored on-demand. 

This can be done with an `OnDemandMatrix{T,VandermondeVector}`. Both the column, or row, vectors and the corresponding points can be stored in the `VandermondeVector` vectors.  

See the following example where I have excluded certain parts for brevity:
```
using CaratheodoryPruning
function vecfun(i)
    # Random point in domain [0,1]^d
    pt = rand(d)
    # Evaluate the basis on this point
    vec = form_vec(pt)
    # Return the Vandermonde basis vector
    return VandermondeVector(vec, pt)
end
V = OnDemandMatrix(N, M, vecfun)
w_in = OnDemandVector(M, x -> 1.0/M)
w,inds = caratheodory_pruning(V, w_in, progress=true)

function quadrature_scheme(f)
    res = 0.0
    for i in inds
        pt = getpt(V.vecs[i])
        res += f(pt) * w[i]
    end
    return res
end
```

The important bit is that evaluating the pruned rule requires memory of the points, `pt = getpt(V.vecs[i])`. And we may not wish to store all `M` points for memory concern.