### PR TITLE
Final (hopefully) version 0.1.0 changes

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,7 +8,8 @@ makedocs(
         "Background" => "index.md",
         "Kernel Downdaters" => "kerneldowndater.md",
         "Pruning" => "pruning.md",
-        "On Demand Matrices" => "ondemand.md",
+        "On Demand Arrays" => "ondemand.md",
+        "MC Example" => "mc_example.md"
     ],
     checkdocs = :none,
     format = Documenter.HTML(prettyurls = false),

--- a/docs/src/mc_example.md
+++ b/docs/src/mc_example.md
@@ -1,0 +1,58 @@
+# Monte Carlo Quadrature Example
+
+Consider the problem of integrating a circle with radius 1 centered at the origin in ``\mathbb{R}^2``, ``C``. One way of doing this is by Monte-Carlo sampling ``M`` points within the circle IID uniformly randomly, ``\{x_i\}_{i=1}^M`` and forming the following quadrature rule
+```math
+\int_C f(x) dx \approx \sum_{i=1}^M \frac{\pi}{M} f(x_i).
+```
+Suppose we wish to accurately integrate the set of bivariate polynomials of degree at most 4, given by the span of ``S = \{1, x, x^2, xy, y^2, \ldots, xy^4, y^5\}`` for which ``N = |S| = \binom{6}{2} = 15``. This means we can form a 15 point quadrature rule which maintains accuracy of the Monte-Carlo rule on ``S``. We can do this through pruning.
+
+Suppose additionally that ``M`` is sufficiently large such that we do not wish to store the full set of ``M`` points in memory. This can be done with an `OnDemandMatrix` and an `OnDemandVector`. See the following code for details.
+
+```julia
+M = 10000
+p = 4 # Polynomial degree
+d = 2 # in R²
+N = binomial(p+d,d)
+
+
+# Form the Vandermonde matrix OnDemand
+vecfun(i) = begin
+    # Form random point in C
+    pt = 2 .* rand(d) .- 1
+    while sum(pt .^ 2) <= 1
+        pt .= 2 .* rand(d) .- 1
+    end
+    # Evaluate point on basis
+    vec = zeros(N)
+    ct = 1
+    for i in 0:p, j in 0:(p-i)
+        vec[ct] = pt[1] ^ i * pt[2] ^ j
+        ct += 1
+    end
+    # Store the vector and point in a Vandermonde vector
+    return VandermondeVector(vec, pt)
+end
+# Store rows and pts OnDemand
+V = OnDemandMatrix(M, N, vecfun, by=:rows, 
+                   TV=VandermondeVector{Float64, Vector{Float64}, Vector{Float64}})
+
+# Store the initial weights OnDemand
+wfun(i) = begin
+    return π / M
+end
+w_in = OnDemandVector(M, wfun)
+
+# Prune and compute reduced weights
+w, inds, err = caratheodory_pruning(V, w_in)
+
+# Function to evaluate reduced rule
+quadrule(f) = begin
+    res = 0.0
+    for i in inds
+        pt = V.vecs[i].pt
+        wt = w[i]
+        res += wt * f(pt)
+    end
+    return res
+end
+```

--- a/docs/src/ondemand.md
+++ b/docs/src/ondemand.md
@@ -21,3 +21,11 @@ OnDemandVector
 ```
 
 The method `forget!` works the same for the `OnDemandVector`.
+
+Related to on demand matrices is a `VandermondeVector` which is a thin wrapper for a standard vector which stores one additional piece of information such as the point used to generate the corresponding slice of the Vandermonde matrix.
+
+```@docs
+VandermondeVector
+```
+
+See the Monte Carlo example for use of this.

--- a/src/CaratheodoryPruning.jl
+++ b/src/CaratheodoryPruning.jl
@@ -1,7 +1,7 @@
 module CaratheodoryPruning
 
 using LinearAlgebra: 
-    qr, I, givens, lmul!, rmul!, ldiv!, rdiv!, QRCompactWYQ, norm, UpperTriangular, SingularException
+    qr, svd, I, givens, lmul!, rmul!, ldiv!, rdiv!, QRCompactWYQ, norm, UpperTriangular, SingularException
 using Random: randperm
 using ProgressBars: ProgressBar, update
 
@@ -11,6 +11,7 @@ include("ondemand_vector.jl")
 include("vandermonde_vec.jl")
 include("kernel.jl")
 include("pruning_weights.jl")
+include("extra_pruning.jl")
 include("caratheodory.jl")
 
 export OnDemandMatrix

--- a/src/caratheodory.jl
+++ b/src/caratheodory.jl
@@ -97,10 +97,6 @@ function caratheodory_pruning(V, w_in, kernel_downdater::KernelDowndater,
         update(pbar, m - pbar.current)
     end
     inds = get_inds(kernel_downdater)
-    # Prune extra
-    if extra_pruning
-        extra_pruning!(V, w, inds, zero_tol, sval_tol)
-    end
     # Compute error
     if caratheodory_correction || return_error
         η_comp = zeros(N)
@@ -109,6 +105,10 @@ function caratheodory_pruning(V, w_in, kernel_downdater::KernelDowndater,
             η_truth .+= (w_in[ind] .* view(V, ind, :))
         end
         err = errnorm(η_comp .- η_truth)
+    end
+    # Prune extra
+    if extra_pruning
+        err += extra_pruning!(V, w, inds, zero_tol, sval_tol)
     end
     # Try to correct weights
     if caratheodory_correction

--- a/src/extra_pruning.jl
+++ b/src/extra_pruning.jl
@@ -16,8 +16,22 @@ sum of the trailing singular values multiplied by the factor used to prune.
 """
 function extra_pruning!(V, w, inds, zero_tol=1e-16, sval_tol=1e-15)
     err = 0.0
+    inds_delete = [false for _ in inds]
+    for i in eachindex(inds)
+        if (abs(w[inds[i]]) < zero_tol)
+            w[inds[i]] = 0.0
+            if isa(w, OnDemandVector)
+                forget!(w, inds[i])
+            end
+            if isa(V, OnDemandMatrix)
+                forget!(V, inds[i])
+            end
+            inds_delete[i] = true
+        end
+    end
+    deleteat!(inds, inds_delete)
     while true
-        _,S,Vmat = svd(view(V, inds, :))
+        _ ,S , Vmat = svd(view(V, inds, :))
         kvec = Vmat[:,end]
 
         if (S[end] / S[1]) > sval_tol

--- a/src/extra_pruning.jl
+++ b/src/extra_pruning.jl
@@ -31,7 +31,7 @@ function extra_pruning!(V, w, inds, zero_tol=1e-16, sval_tol=1e-15)
     end
     deleteat!(inds, inds_delete)
     while true
-        _ ,S , Vmat = svd(view(V, inds, :))
+        _ ,S , Vmat = svd(V[inds, :])
         kvec = Vmat[:,end]
 
         if (S[end] / S[1]) > sval_tol

--- a/src/extra_pruning.jl
+++ b/src/extra_pruning.jl
@@ -1,0 +1,51 @@
+"""
+`extra_pruning!(V, w, inds[, zero_tol=1e-16, sval_tol=1e-15])`
+
+Takes a matrix, `V`, and a vector of weights, `w`, and corresponding
+indices, `inds`, and prunes such that reduces the number of indices, 
+modifying the weights, `w`, and the indices, `inds`, in place maintaining
+the moments given by `η = V[inds,:]ᵀw[inds]`.
+
+It only halts when `σ_min / σ_max > sval_tol` or when 
+`σ_min * α > zero_tol` where `σ_min` is the minimum singular value of 
+`V[inds,:]`, `σ_max` is the maximum singular value of `V[inds,:]`, and 
+`α` is the multiple of the kernel vector that is used to prune the weights.
+"""
+function extra_pruning!(V, w, inds, zero_tol=1e-16, sval_tol=1e-15)
+    if isa(inds, AbstractRange)
+        inds = collect(inds)
+    end
+    while true
+        _,S,Vmat = svd(view(V, inds, :))
+        kvec = Vmat[:,end]
+
+        if (S[end] / S[1]) > sval_tol
+            break
+        end
+        alphan, k0n, alphap, k0p = get_alpha_k0s(w, kvec, inds)
+
+        alpha, k0 = abs(alphan) < abs(alphap) ? (alphan, k0n) : (alphap, k0p)
+
+        if (S[end] * alpha) > zero_tol
+            break
+        end
+
+        inds_delete = [false for _ in inds]
+        for i in eachindex(kvec)
+            w[inds[i]] -= alpha * kvec[i]
+            if (i == k0) || (abs(w[inds[i]]) < zero_tol)
+                w[inds[i]] = 0.0
+                if isa(w, OnDemandVector)
+                    forget!(w, inds[i])
+                end
+                if isa(V, OnDemandMatrix)
+                    forget!(V, inds[i])
+                end
+                inds_delete[i] = true
+            end
+        end
+
+        deleteat!(inds, inds_delete)
+    end
+    return w, inds
+end

--- a/src/extra_pruning.jl
+++ b/src/extra_pruning.jl
@@ -10,11 +10,12 @@ It only halts when `σ_min / σ_max > sval_tol` or when
 `σ_min * α > zero_tol` where `σ_min` is the minimum singular value of 
 `V[inds,:]`, `σ_max` is the maximum singular value of `V[inds,:]`, and 
 `α` is the multiple of the kernel vector that is used to prune the weights.
+
+Returns the error, `err`, induced by the pruning which corresponds to the 
+sum of the trailing singular values multiplied by the factor used to prune.
 """
 function extra_pruning!(V, w, inds, zero_tol=1e-16, sval_tol=1e-15)
-    if isa(inds, AbstractRange)
-        inds = collect(inds)
-    end
+    err = 0.0
     while true
         _,S,Vmat = svd(view(V, inds, :))
         kvec = Vmat[:,end]
@@ -44,8 +45,8 @@ function extra_pruning!(V, w, inds, zero_tol=1e-16, sval_tol=1e-15)
                 inds_delete[i] = true
             end
         end
-
+        err += abs(alpha * S[end])
         deleteat!(inds, inds_delete)
     end
-    return w, inds
+    return err
 end

--- a/src/ondemand_matrix.jl
+++ b/src/ondemand_matrix.jl
@@ -75,14 +75,12 @@ function Base.getindex(M::OnDemandMatrix, idx::Vararg{Int,2})
         if !(j in keys(M.vecs))
             vec = M.vecfun(j)
             push!(M.vecs, j => vec)
-            return vec[i]
         end
         return M.vecs[j][i]
     else
         if !(i in keys(M.vecs))
             vec = M.vecfun(i)
             push!(M.vecs, i => vec)
-            return vec[j]
         end
         return M.vecs[i][j]
     end

--- a/src/ondemand_matrix.jl
+++ b/src/ondemand_matrix.jl
@@ -64,7 +64,6 @@ function Base.show(io::Core.IO, mime::MIME"text/plain", M::OnDemandMatrix)
     Base.show(io, M)
 end
 
-# TODO: Is this the correct way to separate @show from print calls?
 function Base.show(io::Core.IO, M::OnDemandMatrix)
     stored = length(M.vecs)
     print(io, "$(size(M,1))x$(size(M,2)) $(typeof(M)) with $(stored) stored $((M.cols ? "columns" : "rows"))")

--- a/src/ondemand_vector.jl
+++ b/src/ondemand_vector.jl
@@ -55,17 +55,16 @@ function Base.copy(M::OnDemandVector{T}) where T
     return OnDemandVector{T}(M.n, copy(M.elems), M.elemfun)
 end
 
-function Base.getindex(M::OnDemandVector, idx::Vararg{Int,1})
+function Base.getindex(M::OnDemandVector{T}, idx::Vararg{Int,1}) where T
     i, = idx
     if !(i in keys(M.elems))
         val = M.elemfun(i)
         push!(M.elems, i => val)
-        return val
     end
     return M.elems[i]
 end
 
-function Base.setindex!(M::OnDemandVector, v, idx::Vararg{Int,1})
+function Base.setindex!(M::OnDemandVector{T}, v::T, idx::Vararg{Int,1}) where T
     i, = idx
     if i in keys(M.elems)
         M.elems[i] = v

--- a/src/ondemand_vector.jl
+++ b/src/ondemand_vector.jl
@@ -39,14 +39,14 @@ function Base.size(M::OnDemandVector)
     return (M.n,)
 end
 
-function Base.show(io::Core.IO, mime::MIME"text/plain", M::OnDemandVector{T}) where T
+function Base.show(io::Core.IO, mime::MIME"text/plain", M::OnDemandVector)
     stored = length(M.elems)
-    print(io, "$(size(M,1)) OnDemandVector{$T} with $(stored) stored elements")
+    print(io, "$(size(M,1))-element $(typeof(M)) with $(stored) stored elements")
 end
 
 # TODO: Is this the correct way to separate @show from print calls?
-function Base.show(io::Core.IO, M::OnDemandVector{T}) where T
-    print(io, "OnDemandVector{$T}(")
+function Base.show(io::Core.IO, M::OnDemandVector)
+    print(io, "$(typeof(M))(")
     print(io, "elems=$(M.elems),")
     print(io, "elemfun=$(M.elemfun))")
 end

--- a/test/Manifest.toml
+++ b/test/Manifest.toml
@@ -1,46 +1,54 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.2"
+julia_version = "1.11.5"
 manifest_format = "2.0"
 project_hash = "186a6ad084e2cd928872a5af648349e37e0695d2"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
 
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
 
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.1.0+0"
+version = "1.1.1+0"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
 
 [[deps.LinearAlgebra]]
 deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+version = "1.11.0"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
 
 [[deps.Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
 
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
-version = "0.3.23+4"
+version = "0.3.27+1"
 
 [[deps.Random]]
 deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
 
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -48,12 +56,14 @@ version = "0.7.0"
 
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
 
 [[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+version = "1.11.0"
 
 [[deps.libblastrampoline_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
-version = "5.8.0+1"
+version = "5.11.0+0"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using CaratheodoryPruning
 using Test
 using Random: seed!
-using LinearAlgebra: norm
+using LinearAlgebra: norm, I
 
 @testset "CaratheodoryPruning.jl" begin
     seed!(1)
@@ -71,5 +71,13 @@ using LinearAlgebra: norm
         @test norm(V[:,inds3]*w3[inds3] .- V0[:,inds1]*w1[inds1]) <= 1e-6
         @test length(keys(V.vecs)) == N
         @test all([length(V.vecs[i]) == M for i in 1:N])
+    end
+
+    @testset "Extra Pruning" begin
+        V = Matrix{Float64}(I, (10,10))
+        V[end,end] = 1e-16
+        w_in = ones(10)
+        w, inds = caratheodory_pruning(V, w_in, extra_pruning=true)
+        @test !(10 in inds)
     end
 end


### PR DESCRIPTION
Several things added here. None that should impact current use cases.

1. Updated docstrings and docs with a simple example.
2. Introduced option for "extra pruning" which makes use of the SVD. I came across this as potentially useful for tensorized Gauss Quadrature rules (was able to pruned further than the number of moments. This is defaulted to false but now an extra toggle.
3. Removed print statement from `caratheodory_pruning` method to avoid unnecessary print statements in StartUpDG and Trixi.
4. Updated tests to account for this.