### PR TITLE
OnDemand Storage Bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CaratheodoryPruning"
 uuid = "ab320bfc-8242-4797-bfc4-9370c33880e7"
 authors = ["Filip Belik"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,6 +60,7 @@ using LinearAlgebra: norm, I
         @test inds1 == inds2
         @test norm(w1[inds1] .- w2[inds2]) <= 1e-6
         @test norm(V[:,inds2]*w2[inds2] .- V0[:,inds1]*w1[inds1]) <= 1e-6
+        @test length(keys(w_in.elems)) == 0
         @test length(keys(w2.elems)) == N
         @test length(keys(V.vecs)) == N
         # Test if use row-storage instead


### PR DESCRIPTION
Correcting for bug where if input, `w_in`, is stored on demand, while the output, `w`, will be stored sparsely and on demand, `w_in` will become dense over the procedure as elements are not forgotten from it.

![image](https://github.com/user-attachments/assets/a7fcd242-331c-4352-9b65-d2f8f3c31d89)
